### PR TITLE
Modified makefile and source code to work with latest version of MQC

### DIFF
--- a/deltamp2.f03
+++ b/deltamp2.f03
@@ -1,6 +1,5 @@
-INCLUDE 'mqc_binary.F03'
 INCLUDE 'deltamp2_mod.f03'
-      Program deltaMP2
+      program deltaMP2
 !
 !     This program reads AO integrals from a Gaussian matrix file and times
 !     AO-to-MO integral transformations.
@@ -10,7 +9,7 @@ INCLUDE 'deltamp2_mod.f03'
 !
 !     USE Connections
 !
-      use integraltransformation_mod
+      use deltamp2_mod
 !
 !     Variable Declarations
 !
@@ -53,7 +52,7 @@ INCLUDE 'deltamp2_mod.f03'
         call mqc_error('MQCPack version is too old.')
 !
 !     Open the Gaussian matrix file and load the number of atomic centers.
-!
+
       nCommands = command_argument_count()
       if(nCommands.eq.0)  &
         call mqc_error('No command line arguments provided. The input Gaussian matrix file name is required.')
@@ -80,28 +79,10 @@ INCLUDE 'deltamp2_mod.f03'
       flush(iOut)
       moEnergiesAlpha = mqcTmpArray
       if(GMatrixFile%isUnrestricted()) then
-        call mqc_error('UMP2 NYI.')
+        call mqc_error('UHF/UKS NYI.')
       else
         moEnergiesBeta = moEnergiesAlpha
       endIf
-!
-!     Build the list of determinants used in the MP2 expansion. The first
-!     determinant string is the reference. For now, we only consider RMP2
-!     calculations. This means that we need to build a list of opposite=spin
-!     doubles and same-spin doubles. The first version of the program builds all
-!     of these determinants into the list of strings explictly, without any
-!     regard for the permutation symmetries available.
-!
-      
-      
-
-
-
-!
-
-
-
-
 !
 !     Load the MO coefficients.
 !
@@ -134,8 +115,8 @@ INCLUDE 'deltamp2_mod.f03'
       call dpReshape4(nBasis,nBasis,nBasis,nBasis,ERIs%realArray,aoInts)
 !hph-
 
-      if(iPrint.ge.2) call mqc_print_rank4Tensor_array_real(iOut,  &
-        aoInts,header='Intrinsic AO Integrals')
+      if(iPrint.ge.2) call mqc_print_rank4Tensor_array_real(aoInts, &
+      IOut,header='Intrinsic AO Integrals')
 
       write(*,*)' Hrant - FLAG C'
       flush(iOut)
@@ -331,8 +312,8 @@ INCLUDE 'deltamp2_mod.f03'
         write(iOut,5000) 'Quarter Transformation 4',time1-time0
         flush(iOut)
         DeAllocate(partialInts1)
-        if(iPrint.ge.1) call mqc_print_rank4Tensor_array_real(iOut,  &
-          moInts,header='Transformed MO Integrals 2')
+        !if(iPrint.ge.1) call mqc_print_rank4Tensor_array_real(iOut,  &
+        !  moInts,header='Transformed MO Integrals 2')
       endIf
 !
 !     Load up AA MO ERIs from the matrixfile and print them out to ensure the
@@ -552,7 +533,13 @@ INCLUDE 'deltamp2_mod.f03'
               numerator = moInts(i,a,j,b) - moInts(i,b,j,a)
               numerator = numerator*numerator
               if(iPrint.ge.1) write(*,*)' num, denom = ',numerator,deltaIJAB
+              write(*,*) " Andrew i = ",i 
+              write(*,*) " Andrew j = ",j 
+              write(*,*) " Andrew a = ",a 
+              write(*,*) " Andrew b = ",b 
               E2AA = E2AA + numerator/(float(4)*deltaIJAB)
+              write(*,*) " Andrew E2AA = ",E2AA
+              write(*,*) 
             endDo
           endDo
         endDo

--- a/deltamp2.f03
+++ b/deltamp2.f03
@@ -84,6 +84,24 @@ INCLUDE 'deltamp2_mod.f03'
         moEnergiesBeta = moEnergiesAlpha
       endIf
 !
+!     Build the list of determinants used in the MP2 expansion. The first
+!     determinant string is the reference. For now, we only consider RMP2
+!     calculations. This means that we need to build a list of opposite=spin
+!     doubles and same-spin doubles. The first version of the program builds all
+!     of these determinants into the list of strings explictly, without any
+!     regard for the permutation symmetries available.
+!
+      
+      
+
+
+
+!
+
+
+
+
+!
 !     Load the MO coefficients.
 !
       write(*,*)' Hrant -  isUnrestricted: ',GMatrixFile%isUnrestricted()
@@ -533,12 +551,7 @@ INCLUDE 'deltamp2_mod.f03'
               numerator = moInts(i,a,j,b) - moInts(i,b,j,a)
               numerator = numerator*numerator
               if(iPrint.ge.1) write(*,*)' num, denom = ',numerator,deltaIJAB
-              write(*,*) " Andrew i = ",i 
-              write(*,*) " Andrew j = ",j 
-              write(*,*) " Andrew a = ",a 
-              write(*,*) " Andrew b = ",b 
               E2AA = E2AA + numerator/(float(4)*deltaIJAB)
-              write(*,*) " Andrew E2AA = ",E2AA
               write(*,*) 
             endDo
           endDo

--- a/deltamp2.f03
+++ b/deltamp2.f03
@@ -32,7 +32,7 @@ INCLUDE 'deltamp2_mod.f03'
 !
 !     Format Statements
 !
- 1000 Format(1x,'Enter Test Program integralTransformation.')
+ 1000 Format(1x,'Enter Test Program DeltaMP2.')
  1010 Format(1x,'Matrix File: ',A,/)
  1020 Format(1x,'Use ',I3,' shared memory processors.')
  1100 Format(1x,'nAtoms    =',I4,6x,'nBasis  =',I4,6x,'nBasisUse=',I4,/,  &
@@ -42,7 +42,7 @@ INCLUDE 'deltamp2_mod.f03'
  2000 Format(1x,'<',I3,',',I3,' || ',I3,',',I3,' > ... pq=',I3,'  rs=',I3,'  pqrs=',I3)
  3000 Format(/,1x,'E(2)-SS = ',f15.10,' a.u.',4x,'E(2)-OS = ',f15.10,' a.u.')
  5000 Format(1x,'Time (',A,'): ',f8.1,' s.')
- 8999 Format(/,1x,'END OF PROGRAM integralTransformation.')
+ 8999 Format(/,1x,'END OF PROGRAM DeltaMP2.')
 !
 !
       call cpu_time(timeStart)
@@ -330,8 +330,8 @@ INCLUDE 'deltamp2_mod.f03'
         write(iOut,5000) 'Quarter Transformation 4',time1-time0
         flush(iOut)
         DeAllocate(partialInts1)
-        !if(iPrint.ge.1) call mqc_print_rank4Tensor_array_real(iOut,  &
-        !  moInts,header='Transformed MO Integrals 2')
+        !if(iPrint.ge.1) call mqc_print_rank4Tensor_array_real(moInts, &
+        !  iOut,header='Transformed MO Integrals 2')
       endIf
 !
 !     Load up AA MO ERIs from the matrixfile and print them out to ensure the
@@ -552,7 +552,6 @@ INCLUDE 'deltamp2_mod.f03'
               numerator = numerator*numerator
               if(iPrint.ge.1) write(*,*)' num, denom = ',numerator,deltaIJAB
               E2AA = E2AA + numerator/(float(4)*deltaIJAB)
-              write(*,*) 
             endDo
           endDo
         endDo

--- a/deltamp2_mod.f03
+++ b/deltamp2_mod.f03
@@ -1,8 +1,8 @@
       module deltamp2_mod
 !
-!     This module supports the program deltaMP2.
+!     This module supports the program scfEnergyTerms.
 !
-!     -H. P. Hratchian, 2023.
+!     -H. P. Hratchian, 2020.
 !
 !
 !     USE Connections

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 #
 # This is a simple makefile for building spin-squared calculation code.
-#
-MQCDir       = $(mqcinstall)
+# Specify where your MQC_directory is built
+MQCDir       = $(mqc_install)
 MQCMODS      = $(MQCDir)/PGI/mod
 MQCLIB       = $(MQCDir)/PGI/lib
 LIBS         = -llapack -lblas -L$(MQCLIB)
@@ -30,5 +30,8 @@ all: deltamp2.exe
 # Generic rule for building general executable program (*.exe) from a standard
 # f03 source (*.f03) file.
 #
-%.exe: %.f03 %_mod.f03 $(MQCLIB)/libmqc.a
+%.exe: %.f03 %_mod.f03 
 	$(RunF) $(LIBS) $(Prof) -mp -I$(MQCMODS) -o $*.exe $*.f03 $(MQCLIB)/libmqc.a
+clean:
+	rm -rf *.o *.exe *.mod
+


### PR DESCRIPTION
I changed the makefile and the original source code to work with the latest version of MQC.

Had to change the arguement list for "mqc_print_rank4tesnor_array_real" from (Iout,Array) to (Array,Iout)

More modifications are incoming, including taking in a second mqc_matrix